### PR TITLE
fix: resolve issue #2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-pymisp = "*"
+pymisp[fileobjects] = "*"
 defang = "*"
 rich = "*"
 eml-parser = "*"


### PR DESCRIPTION
Fixes the file expansion step by changing the PyMISP dependency from `pymisp` to `pymisp[fileobjects]`. This will install all dependencies required to run file expansions, including `lief`. If the `lief` import is successful, PyMISP reaches the import of `FileObject` which previously fell victim to the catch-all block.


 